### PR TITLE
Expose library as SwiftPM product 📦

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "opentelemetry-swift-xray",
+    products: [
+        .library(name: "OpenTelemetryXRay", targets: ["OpenTelemetryXRay"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/slashmo/opentelemetry-swift.git", .branch("main")),
     ],


### PR DESCRIPTION
The library couldn't be imported without exposing a library SwiftPM product. That's now fixed.